### PR TITLE
Define the OSBuild, OSDistro and OSType as package level variables

### DIFF
--- a/maa/gettoken.go
+++ b/maa/gettoken.go
@@ -16,6 +16,8 @@ import (
 var (
 	// APIVersion is the version of the MAA API to use.
 	APIVersion = "2020-10-01"
+	// AttestEndpoint is the MAA attestation endpoint.
+	AttestEndpoint = "attest/AzureGuest"
 	// OSBuild represents the OS build string.
 	OSBuild = "Edgeless"
 	// OSDistro represents the OS distribution, for example Ubuntu.
@@ -30,7 +32,7 @@ func GetEncryptedToken(ctx context.Context, params Parameters, nonce []byte, maa
 	if maaURL == "" {
 		return "", errors.New("maaURL is empty")
 	}
-	maaURL, err := url.JoinPath(maaURL, "attest/AzureGuest")
+	maaURL, err := url.JoinPath(maaURL, AttestEndpoint)
 	if err != nil {
 		return "", fmt.Errorf("parsing maaURL: %w", err)
 	}

--- a/maa/gettoken.go
+++ b/maa/gettoken.go
@@ -13,6 +13,17 @@ import (
 	"sort"
 )
 
+var (
+	// APIVersion is the version of the MAA API to use.
+	APIVersion = "2020-10-01"
+	// OSBuild represents the OS build string.
+	OSBuild = "Edgeless"
+	// OSDistro represents the OS distribution, for example Ubuntu.
+	OSDistro = "Edgeless"
+	// OSType represents the OS type, for example Linux.
+	OSType = "Edgeless"
+)
+
 // GetEncryptedToken requests a token from MAA, which will be encrypted.
 func GetEncryptedToken(ctx context.Context, params Parameters, nonce []byte, maaURL string, httpClient HttpClient) (string, error) {
 	// create full URL
@@ -23,7 +34,7 @@ func GetEncryptedToken(ctx context.Context, params Parameters, nonce []byte, maa
 	if err != nil {
 		return "", fmt.Errorf("parsing maaURL: %w", err)
 	}
-	maaURL += "?api-version=2020-10-01"
+	maaURL += fmt.Sprintf("?api-version=%s", APIVersion)
 
 	attInfo, err := newAttestationInfo(params)
 	if err != nil {
@@ -122,8 +133,6 @@ func newAttestationInfo(params Parameters) (attestationInfo, error) {
 		pcrs[i].Index = index
 	}
 
-	const edgeless = "Edgeless"
-
 	attInfo := attestationInfo{
 		AttestationProtocolVersion: "2.0",
 		IsolationInfo: isolationInfo{
@@ -136,9 +145,9 @@ func newAttestationInfo(params Parameters) (attestationInfo, error) {
 			},
 			Type: "SevSnp",
 		},
-		OSBuild:  edgeless,
-		OSDistro: edgeless,
-		OSType:   edgeless,
+		OSBuild:  infoString(OSBuild),
+		OSDistro: infoString(OSDistro),
+		OSType:   infoString(OSType),
 		TcgLogs:  eventLog,
 		TpmInfo: tpmInfo{
 			AikCert:                    params.Attestation.AkCert,

--- a/maa/gettoken_test.go
+++ b/maa/gettoken_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"net/http"
+	"net/url"
 	"testing"
 
 	ptpm "github.com/google/go-tpm-tools/proto/tpm"
@@ -52,9 +53,9 @@ func TestGetEncryptedToken(t *testing.T) {
 			},
 			Type: "SevSnp",
 		},
-		OSBuild:  "Edgeless",
-		OSDistro: "Edgeless",
-		OSType:   "Edgeless",
+		OSBuild:  infoString(OSBuild),
+		OSDistro: infoString(OSDistro),
+		OSType:   infoString(OSType),
 		TcgLogs:  specIDEvent,
 		TpmInfo: tpmInfo{
 			AikCert:                    []byte("akcert"),
@@ -126,7 +127,11 @@ func TestGetEncryptedToken(t *testing.T) {
 
 			require.Len(tc.httpClient.requests, 1)
 			req := tc.httpClient.requests[0]
-			assert.Equal(tc.url+"/attest/AzureGuest?api-version=2020-10-01", req.URL.String())
+
+			maaURL, er := url.JoinPath(tc.url, AttestEndpoint)
+			require.NoError(er)
+
+			assert.Equal(maaURL+"?api-version="+APIVersion, req.URL.String())
 			var attReq attestRequest
 			require.NoError(json.NewDecoder(req.Body).Decode(&attReq))
 			assert.Equal(tc.wantAttestationInfo, attReq.AttestationInfo)


### PR DESCRIPTION
This PR replaces the `const edgeless = "Edgeless"` constant with package level variables `OSBuild`, `OSDistro` and `OSType` whose initial value is `"Edgeless"`.